### PR TITLE
Initialize Redux store with auth API

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Provider } from 'react-redux';
 import App from './App';
-import store from './store';
+import { Provider } from 'react-redux';
+import { store } from './store';
+import './styles/main.scss';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
 );
 

--- a/src/store/api/authApi.js
+++ b/src/store/api/authApi.js
@@ -1,0 +1,22 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: '/api', // 🔧 Replace with your actual base URL
+  }),
+  endpoints: (builder) => ({
+    login: builder.mutation({
+      query: (credentials) => ({
+        url: '/auth/login',
+        method: 'POST',
+        body: credentials,
+      }),
+    }),
+    getProfile: builder.query({
+      query: () => '/auth/profile',
+    }),
+  }),
+});
+
+export const { useLoginMutation, useGetProfileQuery } = authApi;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { authApi } from './api/authApi';
 
-export default configureStore({
-  reducer: {},
+export const store = configureStore({
+  reducer: {
+    [authApi.reducerPath]: authApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(authApi.middleware),
 });
 


### PR DESCRIPTION
## Summary
- setup redux store using @reduxjs/toolkit
- add authApi RTK Query slice
- wire redux store into `main.jsx`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c3cc25b0832b9f0f55c515cc4db1