### PR TITLE
Add global context providers and integrate in App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import AppRouter from './routes/AppRouter';
+import { ThemeProvider } from './contexts/ThemeContext';
+import { LanguageProvider } from './contexts/LanguageContext';
+import { UIProvider } from './contexts/UIContext';
 
 const App = () => {
-  return <AppRouter />;
+  return (
+    <ThemeProvider>
+      <LanguageProvider>
+        <UIProvider>
+          <AppRouter />
+        </UIProvider>
+      </LanguageProvider>
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -1,6 +1,20 @@
-import { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 
-const LanguageContext = createContext('en');
+const LanguageContext = createContext();
 
-export default LanguageContext;
+export const useLanguage = () => useContext(LanguageContext);
 
+export const LanguageProvider = ({ children }) => {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = (lng) => {
+    i18n.changeLanguage(lng);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ changeLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,6 +1,21 @@
-import { createContext } from 'react';
+import React, { createContext, useState, useContext, useEffect } from 'react';
 
-const ThemeContext = createContext('light');
+const ThemeContext = createContext();
 
-export default ThemeContext;
+export const useTheme = () => useContext(ThemeContext);
 
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  useEffect(() => {
+    document.body.className = theme;
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/contexts/UIContext.js
+++ b/src/contexts/UIContext.js
@@ -1,6 +1,16 @@
-import { createContext } from 'react';
+import React, { createContext, useState, useContext } from 'react';
 
-const UIContext = createContext({});
+const UIContext = createContext();
 
-export default UIContext;
+export const useUI = () => useContext(UIContext);
 
+export const UIProvider = ({ children }) => {
+  const [isSidebarOpen, setSidebarOpen] = useState(true);
+  const toggleSidebar = () => setSidebarOpen(prev => !prev);
+
+  return (
+    <UIContext.Provider value={{ isSidebarOpen, toggleSidebar }}>
+      {children}
+    </UIContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- implement `ThemeProvider` with theme toggling
- add language change logic in `LanguageProvider`
- create `UIProvider` with sidebar toggle support
- wrap application in all providers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c4fdb278832b93dd7cb7843f274b