### PR TITLE
Configure Redux store with RTK Query APIs

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { Provider } from 'react-redux';
 import { store } from './store';
+import { setupListeners } from '@reduxjs/toolkit/query';
 import './i18n/i18n';
 import './styles/main.scss';
 
@@ -12,5 +13,7 @@ root.render(
     <App />
   </Provider>
 );
+
+setupListeners(store.dispatch);
 
 

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -1,0 +1,14 @@
+export { authApi } from './authApi';
+export { userApi } from './userApi';
+export { translationsApi } from './translationsApi';
+export { paymentApi } from './paymentApi';
+export { referralApi } from './referralApi';
+export { paymentHistoryApi } from './paymentHistoryApi';
+export { notificationsApi } from './notificationsApi';
+export { arbitrageScannerApi } from './arbitrageScannerApi';
+export { arbitrageTemplatesApi } from './arbitrageTemplatesApi';
+export { notificationTemplatesApi } from './notificationTemplatesApi';
+export { notificationBotsApi } from './notificationBotsApi';
+export { blogApi } from './blogApi';
+export { casesApi } from './casesApi';
+export { tutorialsApi } from './tutorialsApi';

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,11 +1,54 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { authApi } from './api/authApi';
+import {
+  authApi,
+  userApi,
+  translationsApi,
+  paymentApi,
+  referralApi,
+  paymentHistoryApi,
+  notificationsApi,
+  arbitrageScannerApi,
+  arbitrageTemplatesApi,
+  notificationTemplatesApi,
+  notificationBotsApi,
+  blogApi,
+  casesApi,
+  tutorialsApi,
+} from './api';
 
 export const store = configureStore({
   reducer: {
     [authApi.reducerPath]: authApi.reducer,
+    [userApi.reducerPath]: userApi.reducer,
+    [translationsApi.reducerPath]: translationsApi.reducer,
+    [paymentApi.reducerPath]: paymentApi.reducer,
+    [referralApi.reducerPath]: referralApi.reducer,
+    [paymentHistoryApi.reducerPath]: paymentHistoryApi.reducer,
+    [notificationsApi.reducerPath]: notificationsApi.reducer,
+    [arbitrageScannerApi.reducerPath]: arbitrageScannerApi.reducer,
+    [arbitrageTemplatesApi.reducerPath]: arbitrageTemplatesApi.reducer,
+    [notificationTemplatesApi.reducerPath]: notificationTemplatesApi.reducer,
+    [notificationBotsApi.reducerPath]: notificationBotsApi.reducer,
+    [blogApi.reducerPath]: blogApi.reducer,
+    [casesApi.reducerPath]: casesApi.reducer,
+    [tutorialsApi.reducerPath]: tutorialsApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(authApi.middleware),
+    getDefaultMiddleware().concat(
+      authApi.middleware,
+      userApi.middleware,
+      translationsApi.middleware,
+      paymentApi.middleware,
+      referralApi.middleware,
+      paymentHistoryApi.middleware,
+      notificationsApi.middleware,
+      arbitrageScannerApi.middleware,
+      arbitrageTemplatesApi.middleware,
+      notificationTemplatesApi.middleware,
+      notificationBotsApi.middleware,
+      blogApi.middleware,
+      casesApi.middleware,
+      tutorialsApi.middleware,
+    ),
 });
 


### PR DESCRIPTION
## Summary
- create aggregator for API slices
- configure Redux store with all RTK Query APIs
- initialize RTK Query listeners in app entry

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d5226c68832b991f7be723f3b710