### PR TITLE
Add routing system with protected routes and layouts

### DIFF
--- a/src/layouts/AuthLayout.jsx
+++ b/src/layouts/AuthLayout.jsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
+const AuthLayout = () => (
+  <div>
+    <main>
+      <Outlet />
+    </main>
+  </div>
+);
+
+export default AuthLayout;

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+const MainLayout = () => (
+  <div>
+    <header>Header</header>
+    <aside>Sidebar</aside>
+    <main>
+      <Outlet />
+    </main>
+  </div>
+);
+
+export default MainLayout;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,3 +1,5 @@
-export const NotFound = () => {
+const NotFound = () => {
   return <h1>404 — Page Not Found</h1>;
 };
+
+export default NotFound;

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,25 +1,59 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import MainLayout from '../layouts/MainLayout';
+import AuthLayout from '../layouts/AuthLayout';
+import ProtectedRoute from './ProtectedRoute';
+
 import LandingPage from '../pages/Landing';
 import LoginPage from '../pages/Login';
+import RegisterPage from '../pages/RegisterPage';
+import BlogPage from '../pages/BlogPage';
+import BlogDetailsPage from '../pages/BlogDetailsPage';
+import CasePage from '../pages/CasePage';
+import CaseDetailsPage from '../pages/CaseDetailsPage';
+import TutorialsPage from '../pages/TutorialsPage';
+
 import DashboardPage from '../pages/Dashboard';
-import ProtectedRoute from './ProtectedRoute';
+import ReferralActivityPage from '../pages/ReferralActivityPage';
+import ReferralWithdrawalsPage from '../pages/ReferralWithdrawalsPage';
+import ScannerDashboardPage from '../pages/ScannerDashboardPage';
+import PaymentHistoryPage from '../pages/PaymentHistoryPage';
+import UserSettingsPage from '../pages/UserSettingsPage';
+import NotificationsPage from '../pages/NotificationsPage';
+
+import NotFound from '../pages/NotFound';
 
 const AppRouter = () => (
   <BrowserRouter>
     <Routes>
-      {/* Public Routes */}
-      <Route path="/" element={<LandingPage />} />
-      <Route path="/login" element={<LoginPage />} />
+      {/* Auth routes */}
+      <Route element={<AuthLayout />}>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+      </Route>
 
-      {/* Protected Routes */}
-      <Route
-        path="/dashboard"
-        element={
-          <ProtectedRoute>
-            <DashboardPage />
-          </ProtectedRoute>
-        }
-      />
+      {/* Public routes */}
+      <Route element={<MainLayout />}>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/blog" element={<BlogPage />} />
+        <Route path="/blog/:id" element={<BlogDetailsPage />} />
+        <Route path="/cases" element={<CasePage />} />
+        <Route path="/cases/:id" element={<CaseDetailsPage />} />
+        <Route path="/tutorials" element={<TutorialsPage />} />
+      </Route>
+
+      {/* Protected routes */}
+      <Route element={<ProtectedRoute><MainLayout /></ProtectedRoute>}>
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/referrals/activity" element={<ReferralActivityPage />} />
+        <Route path="/referrals/withdrawals" element={<ReferralWithdrawalsPage />} />
+        <Route path="/scanner" element={<ScannerDashboardPage />} />
+        <Route path="/payments/history" element={<PaymentHistoryPage />} />
+        <Route path="/settings" element={<UserSettingsPage />} />
+        <Route path="/notifications" element={<NotificationsPage />} />
+      </Route>
+
+      {/* Fallback */}
+      <Route path="*" element={<NotFound />} />
     </Routes>
   </BrowserRouter>
 );

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 const ProtectedRoute = ({ children }) => {
-  const isAuthenticated = !!localStorage.getItem('token'); // Replace with better logic if needed
+  const user = useSelector((state) => state.auth.user);
 
-  return isAuthenticated ? children : <Navigate to="/login" />;
+  return user ? children : <Navigate to="/login" replace />;
 };
 
 export default ProtectedRoute;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './slices/authSlice';
 import {
   authApi,
   userApi,
@@ -18,6 +19,7 @@ import {
 
 export const store = configureStore({
   reducer: {
+    auth: authReducer,
     [authApi.reducerPath]: authApi.reducer,
     [userApi.reducerPath]: userApi.reducer,
     [translationsApi.reducerPath]: translationsApi.reducer,

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser(state, action) {
+      state.user = action.payload;
+    },
+    clearUser(state) {
+      state.user = null;
+    },
+  },
+});
+
+export const { setUser, clearUser } = authSlice.actions;
+export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- create `AuthLayout` and `MainLayout` placeholder components
- implement routing for public and private pages using React Router v6
- add Redux `auth` slice and use it in `ProtectedRoute`
- wire new `AppRouter` with a fallback 404 page

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6c155c0832b8bec5714ac7b16ac