### PR TITLE
Move language dropdown into headers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,14 +3,12 @@ import AppRouter from './routes/AppRouter';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { LanguageProvider } from './contexts/LanguageContext';
 import { UIProvider } from './contexts/UIContext';
-import { LanguageSwitcher } from './components/common/LanguageSwitcher';
 
 const App = () => {
   return (
     <ThemeProvider>
       <LanguageProvider>
         <UIProvider>
-          <LanguageSwitcher />
           <AppRouter />
         </UIProvider>
       </LanguageProvider>

--- a/src/components/layouts/headers/HeaderAuthPages.jsx
+++ b/src/components/layouts/headers/HeaderAuthPages.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { authStyles as styles } from '../../../styles/components/headers';
+import { LanguageSwitcher } from '../../common/LanguageSwitcher';
 
 const HeaderAuthPages = () => {
   const { user } = useSelector((state) => state.auth);
@@ -9,6 +10,7 @@ const HeaderAuthPages = () => {
     <header className={styles.header}>
       <img src="/logo192.png" alt="Logo" className={styles.logo} />
       <div className={styles.actions}>
+        <LanguageSwitcher />
         {user ? (
           <>
             <Link to="/notifications">Notifications</Link>

--- a/src/components/layouts/headers/HeaderLanding.jsx
+++ b/src/components/layouts/headers/HeaderLanding.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { landingStyles as styles } from '../../../styles/components/headers';
+import { LanguageSwitcher } from '../../common/LanguageSwitcher';
 
 const HeaderLanding = () => {
   const { user } = useSelector((state) => state.auth);
@@ -17,6 +18,7 @@ const HeaderLanding = () => {
         </nav>
       </div>
       <div className={styles.actions}>
+        <LanguageSwitcher />
         {user ? (
           <>
             <Link to="/notifications">Notifications</Link>

--- a/src/components/layouts/headers/HeaderMain.jsx
+++ b/src/components/layouts/headers/HeaderMain.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { mainStyles as styles } from '../../../styles/components/headers';
+import { LanguageSwitcher } from '../../common/LanguageSwitcher';
 
 const HeaderMain = () => {
   const { user } = useSelector((state) => state.auth);
@@ -15,6 +16,7 @@ const HeaderMain = () => {
         </nav>
       </div>
       <div className={styles.actions}>
+        <LanguageSwitcher />
         {user ? (
           <>
             <Link to="/notifications">Notifications</Link>


### PR DESCRIPTION
## Summary
- remove LanguageSwitcher from App
- show LanguageSwitcher in each header component

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adf86f874832b91b6e8a9c383509b