### PR TITLE
Add chevron-based sidebar toggle

### DIFF
--- a/src/components/Sidebars/Sidebar.jsx
+++ b/src/components/Sidebars/Sidebar.jsx
@@ -1,23 +1,34 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { NavLink } from 'react-router-dom';
-import { FaBars, FaSignOutAlt, FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import {
+  FaSignOutAlt,
+  FaChevronDown,
+  FaChevronUp,
+  FaChevronLeft,
+  FaChevronRight,
+} from 'react-icons/fa';
 import styles from '../../styles/components/sidebars/Sidebar.module.scss';
 
-const Sidebar = ({ items = [], collapsed = false, onCollapse }) => {
+const Sidebar = ({ items = [] }) => {
   const { user } = useSelector((state) => state.auth);
   const [openIndex, setOpenIndex] = useState(null);
+  const [isOpen, setIsOpen] = useState(true);
 
   const toggleSubmenu = (idx) => {
     setOpenIndex((prev) => (prev === idx ? null : idx));
   };
 
+  const toggleSidebar = () => {
+    setIsOpen((prev) => !prev);
+  };
+
   return (
-    <aside className={styles.sidebar} data-collapsed={collapsed}>
+    <aside className={styles.sidebar} data-collapsed={!isOpen}>
       <div className={styles.top}>
         <img className={styles.avatar} src={user?.avatar || '/logo192.png'} alt="avatar" />
-        {!collapsed && <span className={styles.greeting}>Hey 👋 {user?.username || 'User'}</span>}
-        {!collapsed && <FaBars className={styles.collapseToggle} onClick={onCollapse} />}
+        {isOpen && <span className={styles.greeting}>Hey 👋 {user?.username || 'User'}</span>}
+        {isOpen && <FaChevronLeft className={styles.collapseToggle} onClick={toggleSidebar} />}
       </div>
       <nav className={styles.menu}>
         {items.map((item, idx) => (
@@ -26,15 +37,15 @@ const Sidebar = ({ items = [], collapsed = false, onCollapse }) => {
               <div
                 className={styles.link}
                 onClick={() => toggleSubmenu(idx)}
-                title={collapsed ? item.label : undefined}
+                title={!isOpen ? item.label : undefined}
               >
                 {item.icon}
-                {!collapsed && <span className={styles.label}>{item.label}</span>}
-                {!collapsed && (
+                {isOpen && <span className={styles.label}>{item.label}</span>}
+                {isOpen && (
                   openIndex === idx ? <FaChevronUp className={styles.arrow} /> : <FaChevronDown className={styles.arrow} />
                 )}
               </div>
-              {openIndex === idx && !collapsed && (
+              {openIndex === idx && isOpen && (
                 <div className={styles.submenu}>
                   {item.subItems.map((sub) => (
                     <NavLink
@@ -54,18 +65,21 @@ const Sidebar = ({ items = [], collapsed = false, onCollapse }) => {
               key={item.label}
               to={item.to}
               className={({ isActive }) => `${styles.link} ${isActive ? styles.active : ''}`}
-              title={collapsed ? item.label : undefined}
+              title={!isOpen ? item.label : undefined}
             >
               {item.icon}
-              {!collapsed && <span className={styles.label}>{item.label}</span>}
+              {isOpen && <span className={styles.label}>{item.label}</span>}
             </NavLink>
           )
         ))}
       </nav>
-      <button className={styles.logout} title={collapsed ? 'Logout' : undefined}>
+      <button className={styles.logout} title={!isOpen ? 'Logout' : undefined}>
         <FaSignOutAlt />
-        {!collapsed && <span>Logout</span>}
+        {isOpen && <span>Logout</span>}
       </button>
+      {!isOpen && (
+        <FaChevronRight className={styles.expandToggle} onClick={toggleSidebar} />
+      )}
     </aside>
   );
 };

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,16 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Outlet } from 'react-router-dom';
-import { FaBars } from 'react-icons/fa';
 
 const MainLayout = ({ header, sidebar }) => {
-  const [collapsed, setCollapsed] = useState(false);
-  const toggle = () => setCollapsed((c) => !c);
 
   return (
     <div>
-      <FaBars onClick={toggle} />
       {header}
-      {sidebar && <aside>{React.cloneElement(sidebar, { collapsed, onCollapse: toggle })}</aside>}
+      {sidebar && <aside>{sidebar}</aside>}
       <main>
         <Outlet />
       </main>

--- a/src/styles/components/sidebars/Sidebar.module.scss
+++ b/src/styles/components/sidebars/Sidebar.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   height: 100vh;
   transition: width 0.2s;
+  position: relative;
 
   &[data-collapsed='true'] {
     width: 60px;
@@ -32,6 +33,18 @@
 
 .collapseToggle {
   margin-left: auto;
+  cursor: pointer;
+}
+
+.expandToggle {
+  position: absolute;
+  top: 50%;
+  right: -12px;
+  transform: translateY(-50%);
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 50%;
+  padding: 0.25rem;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- refactor Sidebar to maintain its own open/collapsed state
- swap FaBars toggles with chevron icons
- remove collapsed logic from MainLayout
- style new toggle buttons in SCSS

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af04d6c00832b8e749cd004bdf474