### PR TITLE
Fix sidebar expand icon layering

### DIFF
--- a/src/styles/components/sidebars/Sidebar.module.scss
+++ b/src/styles/components/sidebars/Sidebar.module.scss
@@ -46,6 +46,7 @@
   border-radius: 50%;
   padding: 0.25rem;
   cursor: pointer;
+  z-index: 5;
 }
 
 .menu {


### PR DESCRIPTION
## Summary
- ensure collapsed sidebar chevron is layered above neighbors

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af3c674d8832bab10fa1b6abcd1cf