### PR TITLE
Add dropdown LanguageSwitcher with SCSS styles

### DIFF
--- a/src/assets/images/globe.svg
+++ b/src/assets/images/globe.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20" stroke="currentColor" stroke-width="2" fill="none"/>
+</svg>

--- a/src/components/common/LanguageSwitcher.jsx
+++ b/src/components/common/LanguageSwitcher.jsx
@@ -1,17 +1,47 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import globeIcon from '../../assets/images/globe.svg';
+import styles from '../../styles/components/LanguageSwitcher.module.scss';
 
 export const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
+  const [open, setOpen] = useState(false);
 
-  const changeLanguage = (e) => {
-    i18n.changeLanguage(e.target.value);
+  const languages = [
+    { code: 'en', label: 'English' },
+    { code: 'ru', label: 'Russian' },
+    { code: 'hy', label: 'Armenian' },
+  ];
+
+  const toggle = () => setOpen((prev) => !prev);
+
+  const selectLanguage = (code) => {
+    i18n.changeLanguage(code);
+    setOpen(false);
   };
 
+  const current = i18n.language.slice(0, 2).toUpperCase();
+
   return (
-    <select onChange={changeLanguage} value={i18n.language}>
-      <option value="en">🇬🇧 English</option>
-      <option value="ru">🇷🇺 Russian</option>
-      <option value="hy">🇦🇲 Armenian</option>
-    </select>
+    <div className={styles.switcher}>
+      <div className={styles.current} onClick={toggle}>
+        <img src={globeIcon} alt="language" className={styles.icon} />
+        <span className={styles.lang}>{current}</span>
+        <span className={styles.arrow}>▼</span>
+      </div>
+      {open && (
+        <ul className={styles.dropdown}>
+          {languages.map((lng) => (
+            <li
+              key={lng.code}
+              className={styles.option}
+              onClick={() => selectLanguage(lng.code)}
+            >
+              {lng.label} ({lng.code.toUpperCase()})
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 };

--- a/src/styles/components/LanguageSwitcher.module.scss
+++ b/src/styles/components/LanguageSwitcher.module.scss
@@ -1,0 +1,45 @@
+.switcher {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.current {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+}
+
+.arrow {
+  font-size: 0.75rem;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  margin-top: 0.25rem;
+  list-style: none;
+  padding: 0.25rem 0;
+  min-width: 120px;
+  z-index: 20;
+}
+
+.option {
+  padding: 0.25rem 0.75rem;
+  white-space: nowrap;
+}
+
+.option:hover {
+  background: #f0f0f0;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -12,3 +12,4 @@
 
 @import './layouts/layout';
 @import './components/sidebars/Sidebar.module';
+@import './components/LanguageSwitcher.module';


### PR DESCRIPTION
## Summary
- implement globe-based dropdown LanguageSwitcher
- create LanguageSwitcher SCSS module and include in index.scss
- add globe.svg asset for the new component

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b13342bcc832bbe1eb95482fb8689