### PR TITLE
Fix typography import

### DIFF
--- a/src/styles/base/fonts.scss
+++ b/src/styles/base/fonts.scss
@@ -1,0 +1,10 @@
+$font-family-ibm: 'IBM Plex Sans', sans-serif;
+$font-family-sf: 'SF Pro Display', sans-serif;
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap');
+@import url('https://fonts.cdnfonts.com/css/sf-pro-display');
+
+:root {
+  --font-family-base: #{$font-family-ibm};
+  --font-family-sf: #{$font-family-sf};
+}

--- a/src/styles/base/typography.scss
+++ b/src/styles/base/typography.scss
@@ -1,4 +1,16 @@
-/* Typography styles */
+/* Global typography rules */
+
 body {
-  font-family: sans-serif;
+  font-family: var(--font-family-base);
+  line-height: 1.5;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-family-sf);
+  font-weight: 500;
+  margin: 0 0 0.5rem;
+}
+p {
+  margin: 0 0 1rem;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,4 @@
+@import './base/fonts';
 @import './base/reset';
 @import './base/typography';
 @import './base/variables';

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,2 +1,3 @@
+@import 'base/fonts';
 @import 'variables/colors';
 @import 'base/reset';


### PR DESCRIPTION
## Summary
- define IBM Plex Sans and SF Pro Display font families
- use CSS variables for fonts in global typography rules

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b22fe3740832b9b79ac24e1aed87f