### PR TITLE
Implement common UI components

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from '../../styles/components/Button.module.scss';
+
+const Button = ({ children, className = '', type = 'button', ...props }) => {
+  return (
+    <button type={type} className={`${styles.button} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Dropdown.jsx
+++ b/src/components/common/Dropdown.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import styles from '../../styles/components/Dropdown.module.scss';
+
+const Dropdown = ({ options = [], value, onChange, placeholder = 'Select', className = '' }) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (val) => {
+    onChange && onChange(val);
+    setOpen(false);
+  };
+
+  const selected = options.find((opt) => opt.value === value);
+
+  return (
+    <div className={`${styles.dropdown} ${className}`}>
+      <div className={styles.toggle} onClick={() => setOpen((p) => !p)}>
+        {selected ? selected.label : placeholder}
+      </div>
+      {open && (
+        <ul className={styles.menu}>
+          {options.map((opt) => (
+            <li key={opt.value} onClick={() => handleSelect(opt.value)} className={styles.option}>
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from '../../styles/components/Input.module.scss';
+
+const Input = ({ label, className = '', ...props }) => {
+  return (
+    <label className={`${styles.wrapper} ${className}`}>
+      {label && <span className={styles.label}>{label}</span>}
+      <input className={styles.input} {...props} />
+    </label>
+  );
+};
+
+export default Input;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styles from '../../styles/components/Modal.module.scss';
+
+const Modal = ({ open, onClose, children }) => {
+  if (!open) return null;
+
+  const stopPropagation = (e) => e.stopPropagation();
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={stopPropagation}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/common/Pagination.jsx
+++ b/src/components/common/Pagination.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from '../../styles/components/Pagination.module.scss';
+
+const Pagination = ({ page = 1, total = 1, onChange }) => {
+  const pages = Array.from({ length: total }, (_, i) => i + 1);
+
+  return (
+    <div className={styles.pagination}>
+      <button disabled={page <= 1} onClick={() => onChange && onChange(page - 1)}>
+        &lt;
+      </button>
+      {pages.map((p) => (
+        <button
+          key={p}
+          className={p === page ? styles.active : ''}
+          onClick={() => onChange && onChange(p)}
+        >
+          {p}
+        </button>
+      ))}
+      <button disabled={page >= total} onClick={() => onChange && onChange(page + 1)}>
+        &gt;
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import styles from '../../styles/components/Sidebar.module.scss';
+
+const Sidebar = ({ items = [] }) => {
+  return (
+    <aside className={styles.sidebar}>
+      {items.map((item) => (
+        <NavLink key={item.label} to={item.to} className={styles.link}>
+          {item.label}
+        </NavLink>
+      ))}
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/src/components/common/Table.jsx
+++ b/src/components/common/Table.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from '../../styles/components/Table.module.scss';
+
+const Table = ({ columns = [], data = [], className = '' }) => {
+  return (
+    <table className={`${styles.table} ${className}`}>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col.key || col}>{col.label || col}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, idx) => (
+          <tr key={row.id || idx}>
+            {columns.map((col) => (
+              <td key={col.key || col}>{row[col.key || col]}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default Table;

--- a/src/components/common/Topbar.jsx
+++ b/src/components/common/Topbar.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from '../../styles/components/Topbar.module.scss';
+
+const Topbar = ({ title, actions, className = '' }) => {
+  return (
+    <div className={`${styles.topbar} ${className}`}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.actions}>{actions}</div>
+    </div>
+  );
+};
+
+export default Topbar;


### PR DESCRIPTION
## Summary
- add functional implementations for common components
  - Button, Dropdown, Input, Modal
  - Pagination, Sidebar, Table, Topbar
- these components import matching style modules

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b327ff098832bae3d2f0345e1a1d4