### PR TITLE
Fetch languages dynamically

### DIFF
--- a/src/components/common/LanguageSwitcher.jsx
+++ b/src/components/common/LanguageSwitcher.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGetAvailableLanguagesQuery } from '../../store/api/contentApi';
 import styles from '../../styles/components/LanguageSwitcher.module.scss';
 
 const globeIcon = '/assets/images/globe.png';
@@ -8,16 +9,12 @@ export const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
   const [open, setOpen] = useState(false);
 
-  const languages = [
-    { code: 'en', label: 'English' },
-    { code: 'ru', label: 'Russian' },
-    { code: 'hy', label: 'Armenian' },
-  ];
+  const { data: languages, isLoading, isError } = useGetAvailableLanguagesQuery();
 
   const toggle = () => setOpen((prev) => !prev);
 
   const selectLanguage = (code) => {
-    i18n.changeLanguage(code);
+    i18n.changeLanguage(code.toLowerCase());
     setOpen(false);
   };
 
@@ -32,15 +29,23 @@ export const LanguageSwitcher = () => {
       </div>
       {open && (
         <ul className={styles.dropdown}>
-          {languages.map((lng) => (
-            <li
-              key={lng.code}
-              className={styles.option}
-              onClick={() => selectLanguage(lng.code)}
-            >
-              {lng.label} ({lng.code.toUpperCase()})
-            </li>
-          ))}
+          {isLoading && (
+            <li className={styles.option}>Loading...</li>
+          )}
+          {isError && (
+            <li className={styles.option}>Failed to load</li>
+          )}
+          {!isLoading && !isError &&
+            Array.isArray(languages) &&
+            languages.map((lng) => (
+              <li
+                key={lng.cultureCode}
+                className={styles.option}
+                onClick={() => selectLanguage(lng.cultureCode)}
+              >
+                {lng.displayName} ({lng.cultureCode})
+              </li>
+            ))}
         </ul>
       )}
     </div>

--- a/src/store/api/contentApi.js
+++ b/src/store/api/contentApi.js
@@ -1,0 +1,15 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const contentApi = createApi({
+  reducerPath: 'contentApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'https://apigateway-959167850798.europe-west4.run.app',
+  }),
+  endpoints: (builder) => ({
+    getAvailableLanguages: builder.query({
+      query: () => '/content/api/Language',
+    }),
+  }),
+});
+
+export const { useGetAvailableLanguagesQuery } = contentApi;

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -12,3 +12,4 @@ export { notificationBotsApi } from './notificationBotsApi';
 export { blogApi } from './blogApi';
 export { casesApi } from './casesApi';
 export { tutorialsApi } from './tutorialsApi';
+export { contentApi } from './contentApi';

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,6 +15,7 @@ import {
   blogApi,
   casesApi,
   tutorialsApi,
+  contentApi,
 } from './api';
 
 export const store = configureStore({
@@ -34,6 +35,7 @@ export const store = configureStore({
     [blogApi.reducerPath]: blogApi.reducer,
     [casesApi.reducerPath]: casesApi.reducer,
     [tutorialsApi.reducerPath]: tutorialsApi.reducer,
+    [contentApi.reducerPath]: contentApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
@@ -51,6 +53,7 @@ export const store = configureStore({
       blogApi.middleware,
       casesApi.middleware,
       tutorialsApi.middleware,
+      contentApi.middleware,
     ),
 });
 


### PR DESCRIPTION
## Summary
- create contentApi slice for remote content service
- fetch language list from the API
- update LanguageSwitcher to use the API data
- register contentApi in Redux store

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68705779e45c832b82eb90f138ac1ce0